### PR TITLE
Rework dash rendering

### DIFF
--- a/hersho_mono.sfd
+++ b/hersho_mono.sfd
@@ -297,7 +297,7 @@ NameList: AGL For New Fonts
 DisplaySize: -48
 AntiAlias: 1
 FitToEm: 0
-WinInfo: 0 27 9
+WinInfo: 54 27 9
 BeginPrivate: 0
 EndPrivate
 TeXData: 1 0 0 522190 261095 174063 489685 1048576 174063 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
@@ -1772,7 +1772,9 @@ StartChar: bracketleft
 Encoding: 90 91 55
 Width: 480
 VWidth: 833
-Flags: HW
+Flags: W
+HStem: -69 62<197.5 354> 679 66<203.312 354>
+VStem: 126 52<117.529 549.424>
 LayerCount: 2
 Fore
 SplineSet
@@ -1854,16 +1856,16 @@ StartChar: bar
 Encoding: 123 124 58
 Width: 480
 VWidth: 833
-Flags: W
+Flags: HW
 VStem: 212 56<-76 742>
 LayerCount: 2
 Fore
 SplineSet
-268 742 m 1
- 268 -76 l 1
- 212 -76 l 1
- 212 742 l 1
- 268 742 l 1
+268 747 m 5
+ 268 -71 l 5
+ 212 -71 l 5
+ 212 747 l 5
+ 268 747 l 5
 EndSplineSet
 Validated: 1
 Substitution2: "end_double_arrows-1" double_bar_end

--- a/hersho_mono.sfd
+++ b/hersho_mono.sfd
@@ -43,32 +43,132 @@ HheadDescent: 0
 HheadDOffset: 1
 OS2Vendor: 'PfEd'
 Lookup: 6 0 0 "fixup_arrows_and_dashes" { "catch_long_options"  "catch_short_options"  "fixup_short_dashes_pre"  "fixup_short_dashes_post"  "fixup_mid_arrows"  "fixup_end_arrows"  "fixup_start_arrows"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
-Lookup: 5 0 0 "do_arrows_and_related" { "do_double_greater_start"  "do_double_less_start"  "do_double_bar_start"  "do_logical_or_equals"  "do_logical_or"  "do_greater_greater_greater"  "do_less_less_less"  "do_greater_greater_equal"  "do_less_less_equal"  "do_equal_operator"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
-Lookup: 6 0 1 "fixup_double_arrows" { "fixup_start_double_greater"  "fixup_end_double_greater"  "fixup_start_double_less"  "fixup_end_double_less"  "fixup_start_double_bar"  "fixup_end_double_bar"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
+Lookup: 6 0 1 "fixup_double_arrows" { "fixup_double_greater_start"  "fixup_double_less_start"  "fixup_double_bar_start"  "fixup_double_greater_end"  "fixup_double_less_end"  "fixup_double_bar_end"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
+Lookup: 5 0 0 "resolve_arrows_operator_ambiguity" { "do_logical_or_equals"  "do_logical_or"  "do_greater_greater_greater"  "do_less_less_less"  "do_greater_greater_equal"  "do_less_less_equal"  "do_equal_operator"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
 Lookup: 4 0 1 "auto ligatures" { "programming_symbols"  "numerals_colon"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
-Lookup: 1 0 0 "start_arrows" { "start_arrows-1"  } []
-Lookup: 1 0 0 "start_double_arrows" { "start_double_arrows-1"  } []
-Lookup: 1 0 0 "mid_arrows" { "mid_arrows-1"  } []
-Lookup: 1 0 0 "end_arrows" { "end_arrows_1"  } []
-Lookup: 1 0 0 "end_double_arrows" { "end_double_arrows-1"  } []
+Lookup: 1 0 0 "start_arrows_lookup" { "start_arrows-1"  } []
+Lookup: 1 0 0 "start_double_arrows_lookup" { "start_double_arrows-1"  } []
+Lookup: 1 0 0 "mid_arrows_lookup" { "mid_arrows-1"  } []
+Lookup: 1 0 0 "end_arrows_lookup" { "end_arrows_1"  } []
+Lookup: 1 0 0 "end_double_arrows_lookup" { "end_double_arrows-1"  } []
 Lookup: 4 0 0 "called_ligatures" { "called_ligatures-1"  } []
 Lookup: 2 0 0 "multiple_subs" { "multiple_subs-1"  } []
 Lookup: 1 0 0 "lengthen_dashes" { "lengthen_dashes-1"  } []
 MarkAttachClasses: 1
 DEI: 91125
+ChainSub2: class "fixup_double_bar_end" 3 3 3 1
+  Class: 13 bar bar_right
+  Class: 16 hyphen long_dash
+  BClass: 13 bar bar_right
+  BClass: 16 hyphen long_dash
+  FClass: 13 bar bar_right
+  FClass: 16 hyphen long_dash
+ 1 2 0
+  ClsList: 1
+  BClsList: 1 2
+  FClsList:
+ 1
+  SeqLookup: 0 "end_double_arrows_lookup"
+  ClassNames: "All_Others" "1" "2"
+  BClassNames: "All_Others" "1" "2"
+  FClassNames: "All_Others" "1" "2"
+EndFPST
+ChainSub2: class "fixup_double_less_end" 3 3 3 1
+  Class: 13 less less_end
+  Class: 16 hyphen long_dash
+  BClass: 13 less less_end
+  BClass: 16 hyphen long_dash
+  FClass: 13 less less_end
+  FClass: 16 hyphen long_dash
+ 1 2 0
+  ClsList: 1
+  BClsList: 1 2
+  FClsList:
+ 1
+  SeqLookup: 0 "end_double_arrows_lookup"
+  ClassNames: "All_Others" "1" "2"
+  BClassNames: "All_Others" "1" "2"
+  FClassNames: "All_Others" "1" "2"
+EndFPST
+ChainSub2: class "fixup_double_greater_end" 3 3 3 1
+  Class: 19 greater greater_end
+  Class: 16 hyphen long_dash
+  BClass: 19 greater greater_end
+  BClass: 16 hyphen long_dash
+  FClass: 19 greater greater_end
+  FClass: 16 hyphen long_dash
+ 1 2 0
+  ClsList: 1
+  BClsList: 1 2
+  FClsList:
+ 1
+  SeqLookup: 0 "end_double_arrows_lookup"
+  ClassNames: "All_Others" "1" "2"
+  BClassNames: "All_Others" "1" "2"
+  FClassNames: "All_Others" "1" "2"
+EndFPST
+ChainSub2: class "fixup_double_bar_start" 3 3 3 1
+  Class: 12 bar bar_left
+  Class: 16 hyphen long_dash
+  BClass: 12 bar bar_left
+  BClass: 16 hyphen long_dash
+  FClass: 12 bar bar_left
+  FClass: 16 hyphen long_dash
+ 1 0 2
+  ClsList: 1
+  BClsList:
+  FClsList: 1 2
+ 1
+  SeqLookup: 0 "start_double_arrows_lookup"
+  ClassNames: "All_Others" "1" "2"
+  BClassNames: "All_Others" "1" "2"
+  FClassNames: "All_Others" "1" "2"
+EndFPST
+ChainSub2: class "fixup_double_less_start" 3 3 3 1
+  Class: 15 less less_start
+  Class: 16 hyphen long_dash
+  BClass: 15 less less_start
+  BClass: 16 hyphen long_dash
+  FClass: 15 less less_start
+  FClass: 16 hyphen long_dash
+ 1 0 2
+  ClsList: 1
+  BClsList:
+  FClsList: 1 2
+ 1
+  SeqLookup: 0 "start_double_arrows_lookup"
+  ClassNames: "All_Others" "1" "2"
+  BClassNames: "All_Others" "1" "2"
+  FClassNames: "All_Others" "1" "2"
+EndFPST
+ChainSub2: class "fixup_double_greater_start" 3 1 3 1
+  Class: 21 greater greater_start
+  Class: 16 hyphen long_dash
+  FClass: 21 greater greater_start
+  FClass: 16 hyphen long_dash
+ 1 0 2
+  ClsList: 1
+  BClsList:
+  FClsList: 1 2
+ 1
+  SeqLookup: 0 "start_double_arrows_lookup"
+  ClassNames: "All_Others" "1" "2"
+  BClassNames: "All_Others"
+  FClassNames: "All_Others" "1" "2"
+EndFPST
 ChainSub2: coverage "fixup_start_arrows" 0 0 0 1
  1 0 1
   Coverage: 16 greater less bar
   FCoverage: 16 hyphen long_dash
  1
-  SeqLookup: 0 "start_arrows"
+  SeqLookup: 0 "start_arrows_lookup"
 EndFPST
 ChainSub2: coverage "fixup_end_arrows" 0 0 0 1
  1 1 0
   Coverage: 16 less greater bar
   BCoverage: 16 hyphen long_dash
  1
-  SeqLookup: 0 "end_arrows"
+  SeqLookup: 0 "end_arrows_lookup"
 EndFPST
 ChainSub2: coverage "fixup_mid_arrows" 0 0 0 1
  1 1 1
@@ -76,7 +176,7 @@ ChainSub2: coverage "fixup_mid_arrows" 0 0 0 1
   BCoverage: 16 hyphen long_dash
   FCoverage: 16 hyphen long_dash
  1
-  SeqLookup: 0 "mid_arrows"
+  SeqLookup: 0 "mid_arrows_lookup"
 EndFPST
 ChainSub2: coverage "fixup_short_dashes_post" 0 0 0 1
  1 1 0
@@ -189,90 +289,6 @@ ContextSub2: glyph "do_logical_or" 0 0 0 1
  1
   SeqLookup: 0 "called_ligatures"
 EndFPST
-ChainSub2: glyph "fixup_start_double_bar" 0 0 0 1
- String: 3 bar
- BString: 0 
- FString: 4 bar 
- 1
-  SeqLookup: 0 "start_double_arrows"
-EndFPST
-ChainSub2: glyph "fixup_end_double_bar" 0 0 0 1
- String: 3 bar
- BString: 9 bar_right
- FString: 0 
- 1
-  SeqLookup: 0 "end_double_arrows"
-EndFPST
-ContextSub2: glyph "do_double_bar_start" 0 0 0 1
- String: 14 bar bar hyphen
- BString: 0 
- FString: 0 
- 3
-  SeqLookup: 0 "start_double_arrows"
-  SeqLookup: 1 "start_arrows"
-  SeqLookup: 2 "lengthen_dashes"
-EndFPST
-ContextSub2: glyph "do_double_less_start" 0 0 0 1
- String: 16 less less hyphen
- BString: 0 
- FString: 0 
- 3
-  SeqLookup: 0 "start_double_arrows"
-  SeqLookup: 1 "end_arrows"
-  SeqLookup: 2 "lengthen_dashes"
-EndFPST
-ChainSub2: class "fixup_end_double_less" 3 3 0 1
-  Class0: 17 {Everything Else}
-  Class: 28 less_start double_less_start
-  Class: 4 less
-  BClass: 28 less_start double_less_start
-  BClass: 4 less
- 1 1 0
-  ClsList: 2
-  BClsList: 1
-  FClsList:
- 1
-  SeqLookup: 0 "end_double_arrows"
-  ClassNames: "All_Others" "1" "2"
-  BClassNames: "All_Others" "1" "2"
-EndFPST
-ChainSub2: glyph "fixup_start_double_less" 0 0 0 1
- String: 4 less
- BString: 0 
- FString: 5 less 
- 1
-  SeqLookup: 0 "start_double_arrows"
-EndFPST
-ContextSub2: glyph "do_double_greater_start" 0 0 0 1
- String: 22 greater greater hyphen
- BString: 0 
- FString: 0 
- 3
-  SeqLookup: 0 "start_double_arrows"
-  SeqLookup: 1 "start_arrows"
-  SeqLookup: 2 "lengthen_dashes"
-EndFPST
-ChainSub2: glyph "fixup_start_double_greater" 0 0 0 1
- String: 7 greater
- BString: 0 
- FString: 8 greater 
- 1
-  SeqLookup: 0 "start_double_arrows"
-EndFPST
-ChainSub2: class "fixup_end_double_greater" 3 3 0 1
-  Class: 44 greater_end greater_mid double_greater_start
-  Class: 7 greater
-  BClass: 44 greater_end greater_mid double_greater_start
-  BClass: 7 greater
- 1 1 0
-  ClsList: 2
-  BClsList: 1
-  FClsList:
- 1
-  SeqLookup: 0 "end_double_arrows"
-  ClassNames: "All_Others" "1" "2"
-  BClassNames: "All_Others" "1" "2"
-EndFPST
 LangName: 1033
 Encoding: Custom
 Compacted: 1
@@ -281,7 +297,7 @@ NameList: AGL For New Fonts
 DisplaySize: -48
 AntiAlias: 1
 FitToEm: 0
-WinInfo: 108 27 9
+WinInfo: 0 27 9
 BeginPrivate: 0
 EndPrivate
 TeXData: 1 0 0 522190 261095 174063 489685 1048576 174063 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144

--- a/hersho_mono.sfd
+++ b/hersho_mono.sfd
@@ -42,8 +42,8 @@ HheadAOffset: 1
 HheadDescent: 0
 HheadDOffset: 1
 OS2Vendor: 'PfEd'
-Lookup: 6 0 1 "fixup_arrows" { "fixup_greater_mid"  "fixup_less_mid"  "fixup_greater_end"  "fixup_less_start"  "fixup_bar_mid"  "fixup_bar_end"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
-Lookup: 5 0 0 "do_arrows_and_related" { "do_double_greater_start"  "do_double_less_start"  "do_double_bar_start"  "do_less_mid"  "do_less_start"  "do_less_end"  "do_greater_mid"  "do_greater_end"  "do_greater_start"  "do_bar_start"  "do_logical_or_equals"  "do_logical_or"  "do_greater_greater_greater"  "do_less_less_less"  "do_greater_greater_equal"  "do_less_less_equal"  "do_short_cmdline_options"  "do_long_cmdline_options"  "do_dash_word_separator"  "do_equal_operator"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
+Lookup: 6 0 0 "fixup_arrows_and_dashes" { "catch_long_options"  "catch_short_options"  "fixup_short_dashes_pre"  "fixup_short_dashes_post"  "fixup_mid_arrows"  "fixup_end_arrows"  "fixup_start_arrows"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
+Lookup: 5 0 0 "do_arrows_and_related" { "do_double_greater_start"  "do_double_less_start"  "do_double_bar_start"  "do_logical_or_equals"  "do_logical_or"  "do_greater_greater_greater"  "do_less_less_less"  "do_greater_greater_equal"  "do_less_less_equal"  "do_equal_operator"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
 Lookup: 6 0 1 "fixup_double_arrows" { "fixup_start_double_greater"  "fixup_end_double_greater"  "fixup_start_double_less"  "fixup_end_double_less"  "fixup_start_double_bar"  "fixup_end_double_bar"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
 Lookup: 4 0 1 "auto ligatures" { "programming_symbols"  "numerals_colon"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
 Lookup: 1 0 0 "start_arrows" { "start_arrows-1"  } []
@@ -53,9 +53,77 @@ Lookup: 1 0 0 "end_arrows" { "end_arrows_1"  } []
 Lookup: 1 0 0 "end_double_arrows" { "end_double_arrows-1"  } []
 Lookup: 4 0 0 "called_ligatures" { "called_ligatures-1"  } []
 Lookup: 2 0 0 "multiple_subs" { "multiple_subs-1"  } []
-Lookup: 1 0 0 "shorten_dashes" { "shorten_dashes-1"  } []
+Lookup: 1 0 0 "lengthen_dashes" { "lengthen_dashes-1"  } []
 MarkAttachClasses: 1
 DEI: 91125
+ChainSub2: coverage "fixup_start_arrows" 0 0 0 1
+ 1 0 1
+  Coverage: 16 greater less bar
+  FCoverage: 16 hyphen long_dash
+ 1
+  SeqLookup: 0 "start_arrows"
+EndFPST
+ChainSub2: coverage "fixup_end_arrows" 0 0 0 1
+ 1 1 0
+  Coverage: 16 less greater bar
+  BCoverage: 16 hyphen long_dash
+ 1
+  SeqLookup: 0 "end_arrows"
+EndFPST
+ChainSub2: coverage "fixup_mid_arrows" 0 0 0 1
+ 1 1 1
+  Coverage: 16 greater less bar
+  BCoverage: 16 hyphen long_dash
+  FCoverage: 16 hyphen long_dash
+ 1
+  SeqLookup: 0 "mid_arrows"
+EndFPST
+ChainSub2: coverage "fixup_short_dashes_post" 0 0 0 1
+ 1 1 0
+  Coverage: 6 hyphen
+  BCoverage: 115 hyphen less greater bar greater_start greater_mid less_end less_mid less_start bar_left bar_mid bar_right long_dash
+ 1
+  SeqLookup: 0 "lengthen_dashes"
+EndFPST
+ChainSub2: coverage "fixup_short_dashes_pre" 0 0 0 1
+ 1 0 1
+  Coverage: 6 hyphen
+  FCoverage: 127 hyphen less greater bar greater_end greater_start greater_mid less_end less_mid less_start bar_left bar_mid bar_right long_dash
+ 1
+  SeqLookup: 0 "lengthen_dashes"
+EndFPST
+ChainSub2: class "catch_short_options" 3 3 3 1
+  Class: 6 hyphen
+  Class: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
+  BClass: 6 hyphen
+  BClass: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
+  FClass: 6 hyphen
+  FClass: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
+ 2 0 1
+  ClsList: 1 1
+  BClsList:
+  FClsList: 2
+ 0
+  ClassNames: "All_Others" "1" "2"
+  BClassNames: "All_Others" "1" "2"
+  FClassNames: "All_Others" "1" "2"
+EndFPST
+ChainSub2: class "catch_long_options" 3 3 3 1
+  Class: 6 hyphen
+  Class: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
+  BClass: 6 hyphen
+  BClass: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
+  FClass: 6 hyphen
+  FClass: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
+ 1 0 1
+  ClsList: 1
+  BClsList:
+  FClsList: 2
+ 0
+  ClassNames: "All_Others" "1" "2"
+  BClassNames: "All_Others" "1" "2"
+  FClassNames: "All_Others" "1" "2"
+EndFPST
 ContextSub2: class "do_equal_operator" 3 3 3 2
   Class: 5 equal
   Class: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
@@ -68,74 +136,16 @@ ContextSub2: class "do_equal_operator" 3 3 3 2
   BClsList:
   FClsList:
  1
-  SeqLookup: 0 "shorten_dashes"
+  SeqLookup: 0 "lengthen_dashes"
  2 0 0
   ClsList: 2 1
   BClsList:
   FClsList:
  1
-  SeqLookup: 1 "shorten_dashes"
+  SeqLookup: 1 "lengthen_dashes"
   ClassNames: "All_Others" "1" "2"
   BClassNames: "All_Others" "1" "2"
   FClassNames: "All_Others" "1" "2"
-EndFPST
-ContextSub2: class "do_dash_word_separator" 3 3 3 1
-  Class: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
-  Class: 6 hyphen
-  BClass: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
-  BClass: 6 hyphen
-  FClass: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
-  FClass: 6 hyphen
- 3 0 0
-  ClsList: 1 2 1
-  BClsList:
-  FClsList:
- 1
-  SeqLookup: 1 "shorten_dashes"
-  ClassNames: "All_Others" "1" "2"
-  BClassNames: "All_Others" "1" "2"
-  FClassNames: "All_Others" "1" "2"
-EndFPST
-ContextSub2: class "do_long_cmdline_options" 4 4 4 1
-  Class: 6 hyphen
-  Class: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
-  Class: 5 space
-  BClass: 6 hyphen
-  BClass: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
-  BClass: 5 space
-  FClass: 6 hyphen
-  FClass: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
-  FClass: 5 space
- 4 0 0
-  ClsList: 3 1 1 2
-  BClsList:
-  FClsList:
- 2
-  SeqLookup: 1 "shorten_dashes"
-  SeqLookup: 2 "shorten_dashes"
-  ClassNames: "All_Others" "1" "2" "3"
-  BClassNames: "All_Others" "1" "2" "3"
-  FClassNames: "All_Others" "1" "2" "3"
-EndFPST
-ContextSub2: class "do_short_cmdline_options" 4 4 4 1
-  Class: 5 space
-  Class: 6 hyphen
-  Class: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
-  BClass: 5 space
-  BClass: 6 hyphen
-  BClass: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
-  FClass: 5 space
-  FClass: 6 hyphen
-  FClass: 153 zero one two three four five six seven eight nine A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
- 3 0 0
-  ClsList: 1 2 3
-  BClsList:
-  FClsList:
- 1
-  SeqLookup: 1 "shorten_dashes"
-  ClassNames: "All_Others" "1" "2" "3"
-  BClassNames: "All_Others" "1" "2" "3"
-  FClassNames: "All_Others" "1" "2" "3"
 EndFPST
 ContextSub2: glyph "do_less_less_equal" 0 0 0 1
  String: 15 less less equal
@@ -197,17 +207,19 @@ ContextSub2: glyph "do_double_bar_start" 0 0 0 1
  String: 14 bar bar hyphen
  BString: 0 
  FString: 0 
- 2
+ 3
   SeqLookup: 0 "start_double_arrows"
   SeqLookup: 1 "start_arrows"
+  SeqLookup: 2 "lengthen_dashes"
 EndFPST
 ContextSub2: glyph "do_double_less_start" 0 0 0 1
  String: 16 less less hyphen
  BString: 0 
  FString: 0 
- 2
+ 3
   SeqLookup: 0 "start_double_arrows"
   SeqLookup: 1 "end_arrows"
+  SeqLookup: 2 "lengthen_dashes"
 EndFPST
 ChainSub2: class "fixup_end_double_less" 3 3 0 1
   Class0: 17 {Everything Else}
@@ -235,9 +247,10 @@ ContextSub2: glyph "do_double_greater_start" 0 0 0 1
  String: 22 greater greater hyphen
  BString: 0 
  FString: 0 
- 2
+ 3
   SeqLookup: 0 "start_double_arrows"
   SeqLookup: 1 "start_arrows"
+  SeqLookup: 2 "lengthen_dashes"
 EndFPST
 ChainSub2: glyph "fixup_start_double_greater" 0 0 0 1
  String: 7 greater
@@ -260,99 +273,9 @@ ChainSub2: class "fixup_end_double_greater" 3 3 0 1
   ClassNames: "All_Others" "1" "2"
   BClassNames: "All_Others" "1" "2"
 EndFPST
-ContextSub2: glyph "do_bar_start" 0 0 0 1
- String: 10 bar hyphen
- BString: 0 
- FString: 0 
- 1
-  SeqLookup: 0 "start_arrows"
-EndFPST
-ChainSub2: glyph "fixup_bar_end" 0 0 0 1
- String: 3 bar
- BString: 6 hyphen
- FString: 0 
- 1
-  SeqLookup: 0 "end_arrows"
-EndFPST
-ChainSub2: glyph "fixup_bar_mid" 0 0 0 1
- String: 3 bar
- BString: 6 hyphen
- FString: 7 hyphen 
- 1
-  SeqLookup: 0 "mid_arrows"
-EndFPST
-ChainSub2: glyph "fixup_less_start" 0 0 0 1
- String: 4 less
- BString: 6 hyphen
- FString: 0 
- 1
-  SeqLookup: 0 "start_arrows"
-EndFPST
-ContextSub2: glyph "do_less_end" 0 0 0 1
- String: 11 less hyphen
- BString: 0 
- FString: 0 
- 1
-  SeqLookup: 0 "end_arrows"
-EndFPST
-ChainSub2: glyph "fixup_less_mid" 0 0 0 1
- String: 4 less
- BString: 6 hyphen
- FString: 7 hyphen 
- 1
-  SeqLookup: 0 "mid_arrows"
-EndFPST
-ContextSub2: glyph "do_less_mid" 0 0 0 1
- String: 18 hyphen less hyphen
- BString: 0 
- FString: 0 
- 1
-  SeqLookup: 1 "mid_arrows"
-EndFPST
-ChainSub2: glyph "fixup_greater_end" 0 0 0 1
- String: 7 greater
- BString: 6 hyphen
- FString: 0 
- 1
-  SeqLookup: 0 "end_arrows"
-EndFPST
-ContextSub2: glyph "do_less_start" 0 0 0 1
- String: 11 hyphen less
- BString: 0 
- FString: 0 
- 1
-  SeqLookup: 1 "start_arrows"
-EndFPST
-ChainSub2: glyph "fixup_greater_mid" 0 0 0 1
- String: 7 greater
- BString: 6 hyphen
- FString: 7 hyphen 
- 1
-  SeqLookup: 0 "mid_arrows"
-EndFPST
-ContextSub2: glyph "do_greater_mid" 0 0 0 1
- String: 21 hyphen greater hyphen
- BString: 0 
- FString: 0 
- 1
-  SeqLookup: 1 "mid_arrows"
-EndFPST
-ContextSub2: glyph "do_greater_start" 0 0 0 1
- String: 14 greater hyphen
- BString: 0 
- FString: 0 
- 1
-  SeqLookup: 0 "start_arrows"
-EndFPST
-ContextSub2: glyph "do_greater_end" 0 0 0 1
- String: 14 hyphen greater
- BString: 0 
- FString: 0 
- 1
-  SeqLookup: 1 "end_arrows"
-EndFPST
 LangName: 1033
 Encoding: Custom
+Compacted: 1
 UnicodeInterp: none
 NameList: AGL For New Fonts
 DisplaySize: -48
@@ -361,19 +284,8 @@ FitToEm: 0
 WinInfo: 108 27 9
 BeginPrivate: 0
 EndPrivate
-Grid
-0 531 m 5
- 94 531 l 5
- 94 322 l 5
- 480 322 l 1
- 480 243 l 1
- 94 243 l 5
- 94 33 l 5
- 0 32 l 5
- 0 531 l 5
-EndSplineSet
 TeXData: 1 0 0 522190 261095 174063 489685 1048576 174063 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-BeginChars: 337 337
+BeginChars: 338 337
 
 StartChar: o
 Encoding: 110 111 0
@@ -2743,26 +2655,25 @@ SplineSet
  480 419 l 1
 EndSplineSet
 Validated: 1
-Substitution2: "shorten_dashes-1" narrow_equal
+Substitution2: "lengthen_dashes-1" narrow_equal
 EndChar
 
 StartChar: hyphen
 Encoding: 44 45 87
 Width: 480
 VWidth: 833
-Flags: W
-HStem: 243 79<0 480>
+Flags: HW
 LayerCount: 2
 Fore
 SplineSet
-480 243 m 5
- 0 243 l 1
- 0 322 l 1
- 480 322 l 5
- 480 243 l 5
+403 248 m 1
+ 77 248 l 1
+ 77 317 l 1
+ 403 317 l 1
+ 403 248 l 1
 EndSplineSet
 Validated: 1
-Substitution2: "shorten_dashes-1" narrow_dash
+Substitution2: "lengthen_dashes-1" long_dash
 EndChar
 
 StartChar: underscore
@@ -3949,7 +3860,13 @@ VWidth: 833
 Flags: HW
 LayerCount: 2
 Fore
-Refer: 335 -1 N 1 0 0 1 0 0 2
+SplineSet
+403 248 m 1
+ 77 248 l 1
+ 77 317 l 1
+ 403 317 l 1
+ 403 248 l 1
+EndSplineSet
 Validated: 1
 EndChar
 
@@ -7023,16 +6940,16 @@ HStem: 243 79<208 479>
 LayerCount: 2
 Fore
 SplineSet
-320 74 m 5
- 0 284 l 5
- 106 349 213 417 320 482 c 5
- 320 391 l 5
- 208 322 l 5
- 479 322 l 1
- 479 243 l 1
- 208 243 l 5
- 320 166 l 5
- 320 74 l 5
+480 74 m 5
+ 217 243 l 5
+ 0 243 l 5
+ 0 323 l 5
+ 217 323 l 5
+ 480 482 l 5
+ 480 391 l 5
+ 307 281 l 5
+ 480 166 l 5
+ 480 74 l 5
 EndSplineSet
 Validated: 1
 EndChar
@@ -7065,21 +6982,21 @@ EndChar
 StartChar: less_start
 Encoding: 325 -1 325
 Width: 480
-Flags: HW
-HStem: 243 79<0 217>
+Flags: W
+HStem: 243 79<208 479>
 LayerCount: 2
 Fore
 SplineSet
-480 74 m 1
- 217 243 l 1
- 0 243 l 1
- 0 323 l 1
- 217 323 l 1
- 480 482 l 1
- 480 391 l 1
- 307 281 l 1
- 480 166 l 1
- 480 74 l 1
+320 74 m 5
+ 0 284 l 5
+ 106 349 213 417 320 482 c 5
+ 320 391 l 5
+ 208 322 l 5
+ 479 322 l 1
+ 479 243 l 1
+ 208 243 l 5
+ 320 166 l 5
+ 320 74 l 5
 EndSplineSet
 Validated: 1
 EndChar
@@ -7245,25 +7162,8 @@ EndSplineSet
 Validated: 1
 EndChar
 
-StartChar: narrow_dash
-Encoding: 335 -1 335
-Width: 480
-VWidth: 833
-Flags: HW
-LayerCount: 2
-Fore
-SplineSet
-403 248 m 1
- 77 248 l 1
- 77 317 l 1
- 403 317 l 1
- 403 248 l 1
-EndSplineSet
-Validated: 1
-EndChar
-
 StartChar: narrow_equal
-Encoding: 336 -1 336
+Encoding: 336 -1 335
 Width: 480
 VWidth: 833
 Flags: W
@@ -7282,6 +7182,24 @@ SplineSet
  79 335 l 1
  79 419 l 1
  401 419 l 1
+EndSplineSet
+Validated: 1
+EndChar
+
+StartChar: long_dash
+Encoding: 337 -1 336
+Width: 480
+VWidth: 833
+Flags: W
+HStem: 243 79<0 480>
+LayerCount: 2
+Fore
+SplineSet
+480 243 m 5
+ 0 243 l 1
+ 0 322 l 1
+ 480 322 l 5
+ 480 243 l 5
 EndSplineSet
 Validated: 1
 EndChar

--- a/hersho_mono.sfd
+++ b/hersho_mono.sfd
@@ -44,7 +44,8 @@ HheadDOffset: 1
 OS2Vendor: 'PfEd'
 Lookup: 6 0 0 "fixup_arrows_and_dashes" { "catch_long_options"  "catch_short_options"  "fixup_short_dashes_pre"  "fixup_short_dashes_post"  "fixup_mid_arrows"  "fixup_end_arrows"  "fixup_start_arrows"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
 Lookup: 6 0 1 "fixup_double_arrows" { "fixup_double_greater_start"  "fixup_double_less_start"  "fixup_double_bar_start"  "fixup_double_greater_end"  "fixup_double_less_end"  "fixup_double_bar_end"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
-Lookup: 5 0 0 "resolve_arrows_operator_ambiguity" { "do_logical_or_equals"  "do_logical_or"  "do_greater_greater_greater"  "do_less_less_less"  "do_greater_greater_equal"  "do_less_less_equal"  "do_equal_operator"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
+Lookup: 6 0 0 "fixup_arrowhead_vs_operator" { "do_logical_or"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
+Lookup: 5 0 0 "resolve_arrows_operator_ambiguity" { "do_logical_or_equals"  "do_greater_greater_greater"  "do_less_less_less"  "do_greater_greater_equal"  "do_less_less_equal"  "do_equal_operator"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
 Lookup: 4 0 1 "auto ligatures" { "programming_symbols"  "numerals_colon"  } ['liga' ('DFLT' <'dflt' > 'latn' <'dflt' > ) ]
 Lookup: 1 0 0 "start_arrows_lookup" { "start_arrows-1"  } []
 Lookup: 1 0 0 "start_double_arrows_lookup" { "start_double_arrows-1"  } []
@@ -52,10 +53,26 @@ Lookup: 1 0 0 "mid_arrows_lookup" { "mid_arrows-1"  } []
 Lookup: 1 0 0 "end_arrows_lookup" { "end_arrows_1"  } []
 Lookup: 1 0 0 "end_double_arrows_lookup" { "end_double_arrows-1"  } []
 Lookup: 4 0 0 "called_ligatures" { "called_ligatures-1"  } []
-Lookup: 2 0 0 "multiple_subs" { "multiple_subs-1"  } []
 Lookup: 1 0 0 "lengthen_dashes" { "lengthen_dashes-1"  } []
 MarkAttachClasses: 1
 DEI: 91125
+ChainSub2: class "do_logical_or" 3 3 3 1
+  Class: 3 bar
+  Class: 413 uni0009 space exclam quotedbl numbersign dollar percent ampersand quotesingle parenleft parenright asterisk plus comma hyphen period slash zero one two three four five six seven eight nine colon less equal greater question at A B C D E F G H I J K L M N O P Q R S T U V W X Y Z backslash asciicircum underscore grave a b c d e f g h i j k l m n o p q r s t u v w x y z braceleft braceright asciitilde bracketright
+  BClass: 3 bar
+  BClass: 413 uni0009 space exclam quotedbl numbersign dollar percent ampersand quotesingle parenleft parenright asterisk plus comma hyphen period slash zero one two three four five six seven eight nine colon less equal greater question at A B C D E F G H I J K L M N O P Q R S T U V W X Y Z backslash asciicircum underscore grave a b c d e f g h i j k l m n o p q r s t u v w x y z braceleft braceright asciitilde bracketright
+  FClass: 3 bar
+  FClass: 413 uni0009 space exclam quotedbl numbersign dollar percent ampersand quotesingle parenleft parenright asterisk plus comma hyphen period slash zero one two three four five six seven eight nine colon less equal greater question at A B C D E F G H I J K L M N O P Q R S T U V W X Y Z backslash asciicircum underscore grave a b c d e f g h i j k l m n o p q r s t u v w x y z braceleft braceright asciitilde bracketright
+ 2 1 0
+  ClsList: 1 1
+  BClsList: 2
+  FClsList:
+ 1
+  SeqLookup: 0 "called_ligatures"
+  ClassNames: "0" "1" "2"
+  BClassNames: "0" "1" "2"
+  FClassNames: "0" "1" "2"
+EndFPST
 ChainSub2: class "fixup_double_bar_end" 3 3 3 1
   Class: 13 bar bar_right
   Class: 16 hyphen long_dash
@@ -282,13 +299,6 @@ ContextSub2: glyph "do_logical_or_equals" 0 0 0 1
  1
   SeqLookup: 0 "called_ligatures"
 EndFPST
-ContextSub2: glyph "do_logical_or" 0 0 0 1
- String: 7 bar bar
- BString: 0 
- FString: 0 
- 1
-  SeqLookup: 0 "called_ligatures"
-EndFPST
 LangName: 1033
 Encoding: Custom
 Compacted: 1
@@ -297,7 +307,7 @@ NameList: AGL For New Fonts
 DisplaySize: -48
 AntiAlias: 1
 FitToEm: 0
-WinInfo: 54 27 9
+WinInfo: 0 27 9
 BeginPrivate: 0
 EndPrivate
 TeXData: 1 0 0 522190 261095 174063 489685 1048576 174063 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
@@ -6085,7 +6095,6 @@ Fore
 Refer: 58 124 S 1 0 0 1 362 0 2
 Refer: 58 124 S 1 0 0 1 118 0 2
 Validated: 1
-MultipleSubs2: "multiple_subs-1" double_bar_start bar_left
 Ligature2: "called_ligatures-1" bar bar
 LCarets2: 1 0
 EndChar


### PR DESCRIPTION
Glyphs being rendered a word at a time, as done in some terminals, prevents the font engine from ever seeing some of our previous readability fixups relevant to dashes. This PR attempts to remedy that by reworking how hyphens are rendered. 

The change here is to make the hyphens use the narrow width by default. The full width is only used when used as part of an arrow segment. Changes will also need to be made to make sure the operators that use the same characters as the arrow heads and the dashes will still be rendered correctly. 

Note that this PR will only deal with single  line dashes. We are dealing with double line dashes, those formed from the equal character  (`=`) , in a later PR. 